### PR TITLE
Fix pinokio update to pull from prebuilt branch

### DIFF
--- a/update.js
+++ b/update.js
@@ -2,13 +2,13 @@ module.exports = {
   run: [{
     method: "shell.run",
     params: {
-      message: "git pull"
+      message: "git pull https://github.com/6Morpheus6/Hunyuan3d-2-lowvram.git prebuilt"
     }
   }, {
     method: "shell.run",
     params: {
       path: "app",
-      message: "git pull"
+      message: "git pull https://github.com/6Morpheus6/Hunyuan3d-2-lowvram.git prebuilt"
     }
   }, {
     method: "fs.rm",


### PR DESCRIPTION
Update the update.js script to pull from the 6Morpheus6 repository's prebuilt branch instead of the current fork's main branch. This ensures users get the latest prebuilt version when clicking update in the pinokio launcher.

🤖 Generated with [Claude Code](https://claude.ai/code)